### PR TITLE
disable ipv6 by default.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,7 @@ RUN chmod -v +x /etc/service/*/run /etc/my_init.d/*.sh && \
 mv /etc/forked-daapd.conf /defaults/forked-daapd.conf && \
 sed -i -e 's/\(uid.*=\).*/\1 \"abc\"/g' /defaults/forked-daapd.conf && \
 sed -i s#"My Music on %h"#"LS.IO Music"#g /defaults/forked-daapd.conf && \
+sed -i s#"ivp6 = yes"#"ivp6 = no"#g /defaults/forked-daapd.conf && \
 sed -i s#/srv/music#/music#g /defaults/forked-daapd.conf && \
 sed -i s#/var/cache/forked-daapd/songs3.db#/config/dbase_and_logs/songs3.db#g /defaults/forked-daapd.conf && \
 sed -i s#/var/cache/forked-daapd/cache.db#/config/dbase_and_logs/cache.db#g /defaults/forked-daapd.conf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ RUN chmod -v +x /etc/service/*/run /etc/my_init.d/*.sh && \
 mv /etc/forked-daapd.conf /defaults/forked-daapd.conf && \
 sed -i -e 's/\(uid.*=\).*/\1 \"abc\"/g' /defaults/forked-daapd.conf && \
 sed -i s#"My Music on %h"#"LS.IO Music"#g /defaults/forked-daapd.conf && \
-sed -i s#"ivp6 = yes"#"ivp6 = no"#g /defaults/forked-daapd.conf && \
+sed -i s#"ipv6 = yes"#"ipv6 = no"#g /defaults/forked-daapd.conf && \
 sed -i s#/srv/music#/music#g /defaults/forked-daapd.conf && \
 sed -i s#/var/cache/forked-daapd/songs3.db#/config/dbase_and_logs/songs3.db#g /defaults/forked-daapd.conf && \
 sed -i s#/var/cache/forked-daapd/cache.db#/config/dbase_and_logs/cache.db#g /defaults/forked-daapd.conf && \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ For further setup options of remotes etc, check out the daapd website, link abov
 
 
 ## Versions
++ **04.01.2016:** Disable ipv6 by default because in v23.4 it doesn't work in unraid with it set. 
 + **17.12.2015:** Add in spotify support.
 + **25.11.2015:** Initial Release. 
 


### PR DESCRIPTION
before the latest version, if the system didn't support it, it wasn't enabled.

now it doesn't do that, bizarrely in this version now though, if it's disabled in the config file and the system supports ipv6 it gets enabled anyways.
