### PR TITLE
configure options to mitigate V26 crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,9 +85,14 @@ RUN \
 	/tmp/source/forked-daapd --strip-components=1 && \
  export PATH="/tmp/source:$PATH" && \
  cd /tmp/source/forked-daapd && \
+ echo "**** fetch updated configure file if version equals 26.0 ****" && \
+ if [ $DAAPD_VER==26.0 ]; then \
+	curl -o /tmp/source/forked-daapd/configure.ac -L \
+	https://raw.githubusercontent.com/ejurgensen/forked-daapd/master/configure.ac; fi && \
  autoreconf -i -v && \
  ./configure \
 	--build=$CBUILD \
+	--disable-avcodecsend \
 	--enable-chromecast \
 	--enable-itunes \
 	--enable-lastfm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN \
  echo "**** fetch updated configure file if version equals 26.0 ****" && \
  if [ $DAAPD_VER==26.0 ]; then \
 	curl -o /tmp/source/forked-daapd/configure.ac -L \
-	https://raw.githubusercontent.com/ejurgensen/forked-daapd/master/configure.ac; fi && \
+	"https://raw.githubusercontent.com/ejurgensen/forked-daapd/5e13bac8672bd866d43e1988ff8aa831b704d9b4/configure.ac" ; fi && \
  autoreconf -i -v && \
  ./configure \
 	--build=$CBUILD \

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ For further setup options of remotes etc, check out the daapd website, [Forked-d
 
 ## Versions
 
++ **05.03.18:** Use configure ac from and disable avcodecsend to hopefully mitigate crashes with V26.
 + **25.02.18:** Query version before pull and build latest release.
 + **03.01.18:** Deprecate cpu_core routine lack of scaling.
 + **07.12.17:** Rebase to alpine linux 3.7.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For further setup options of remotes etc, check out the daapd website, [Forked-d
 
 ## Versions
 
-+ **05.03.18:** Use configure ac from master and disable avcodecsend to hopefully mitigate crashes with V26.
++ **05.03.18:** Use updated configure ac and disable avcodecsend to hopefully mitigate crashes with V26.
 + **25.02.18:** Query version before pull and build latest release.
 + **03.01.18:** Deprecate cpu_core routine lack of scaling.
 + **07.12.17:** Rebase to alpine linux 3.7.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ For further setup options of remotes etc, check out the daapd website, [Forked-d
 
 ## Versions
 
-+ **05.03.18:** Use configure ac from and disable avcodecsend to hopefully mitigate crashes with V26.
++ **05.03.18:** Use configure ac from master and disable avcodecsend to hopefully mitigate crashes with V26.
 + **25.02.18:** Query version before pull and build latest release.
 + **03.01.18:** Deprecate cpu_core routine lack of scaling.
 + **07.12.17:** Rebase to alpine linux 3.7.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ as per https://github.com/ejurgensen/forked-daapd/issues/502#issuecomment-370264870
+ ffmpeg latest version in edge was still producing crashes so went with updating configure ac file and options