### PR TITLE
New: Usr: Enabled Spotify for x86_64 and armv7

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -41,7 +41,7 @@ RUN \
 	taglib-dev \
 	tar && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://nl.alpinelinux.org/alpine/edge/community \
 	mxml-dev && \
  echo "**** make antlr wrapper ****" && \
  mkdir -p \
@@ -123,7 +123,7 @@ RUN \
 	sqlite \
 	sqlite-libs && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://nl.alpinelinux.org/alpine/edge/community \
 	mxml
 
 # copy buildstage and local files

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -2,6 +2,8 @@ FROM lsiobase/alpine:arm32v7-3.12 as buildstage
 ############## build stage ##############
 
 ARG DAAPD_RELEASE
+ARG LIBSPOTIFY_VERSION=12.1.51
+ARG ARCH=armv7
 
 RUN \
  echo "**** install build packages ****" && \
@@ -41,7 +43,7 @@ RUN \
 	taglib-dev \
 	tar && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://nl.alpinelinux.org/alpine/edge/community \
 	mxml-dev && \
  echo "**** make antlr wrapper ****" && \
  mkdir -p \
@@ -70,6 +72,11 @@ RUN \
 	DAAPD_RELEASE=$(curl -sX GET "https://api.github.com/repos/ejurgensen/forked-daapd/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
  fi && \
+ curl -L https://github.com/mopidy/libspotify-archive/blob/master/libspotify-${LIBSPOTIFY_VERSION}-Linux-${ARCH}-release.tar.gz?raw=true | tar -xzf- -C /tmp/source/ && \
+ mv /tmp/source/libspotify* /tmp/source/libspotify && \
+ sed -i 's/ldconfig//' /tmp/source/libspotify/Makefile && \
+ make -C /tmp/source/libspotify prefix=/tmp/libspotify-build install && \
+ rm -rf /tmp/source/libspotify && \
  curl -o \
  /tmp/source/forked.tar.gz -L \
 	"https://github.com/ejurgensen/forked-daapd/archive/${DAAPD_RELEASE}.tar.gz" && \
@@ -123,12 +130,13 @@ RUN \
 	sqlite \
 	sqlite-libs && \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	--repository http://nl.alpinelinux.org/alpine/edge/community \
 	mxml
 
 # copy buildstage and local files
 COPY --from=buildstage /tmp/daapd-build/ /
 COPY --from=buildstage /tmp/antlr3c-build/ /
+COPY --from=buildstage /tmp/libspotify-build/ /
 COPY root/ /
 
 # ports and volumes

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **06.10.20:** - Enabled Spotify on Alpine 3.12 for X86_64 and ARMv7.
 * **01.06.20:** - Rebasing to alpine 3.12.
 * **16.01.20:** - Rebase to alpine linux 3.11 and build antlr3c from source.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -53,6 +53,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "06.10.20:", desc: "Enabled Spotify on Alpine 3.12 for X86_64 and ARMv7." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }
   - { date: "16.01.20:", desc: "Rebase to alpine linux 3.11 and build antlr3c from source." } 
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
## Description:
Installed libspotify and enabled forked-daapd build with libspotify.

## Benefits of this PR and context:
Fixes #36 

## How Has This Been Tested?
- Tested fully on x86_64
- Tested partially on armv7
- No changes to arm64

## Source / References:
