### PR TITLE
New: Usr: Removed librespot daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,10 +133,7 @@ RUN \
 	sqlite-libs && \
  apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/community \
-	mxml && \
- apk add --no-cache \
-    --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
-    librespot
+	mxml
 
 # copy buildstage and local files
 COPY --from=buildstage /tmp/daapd-build/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -124,10 +124,7 @@ RUN \
 	sqlite-libs && \
  apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/community \
-	mxml && \
- apk add --no-cache \
-    --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
-    librespot
+	mxml
 
 # copy buildstage and local files
 COPY --from=buildstage /tmp/daapd-build/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -2,6 +2,7 @@ FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.12 as buildstage
 ############## build stage ##############
 
 ARG DAAPD_RELEASE
+ARG LIBSPOTIFY_VERSION=12.1.51
 ARG ARCH=armv7
 
 RUN \
@@ -71,6 +72,11 @@ RUN \
 	DAAPD_RELEASE=$(curl -sX GET "https://api.github.com/repos/owntone/owntone-server/releases/latest" \
 	| awk '/tag_name/{print $4;exit}' FS='[""]'); \
  fi && \
+ curl -L https://github.com/mopidy/libspotify-archive/blob/master/libspotify-${LIBSPOTIFY_VERSION}-Linux-${ARCH}-release.tar.gz?raw=true | tar -xzf- -C /tmp/source/ && \
+ mv /tmp/source/libspotify* /tmp/source/libspotify && \
+ sed -i 's/ldconfig//' /tmp/source/libspotify/Makefile && \
+ make -C /tmp/source/libspotify prefix=/tmp/libspotify-build install && \
+ rm -rf /tmp/source/libspotify && \
  curl -o \
  /tmp/source/owntone.tar.gz -L \
 	"https://github.com/owntone/owntone-server/archive/${DAAPD_RELEASE}.tar.gz" && \
@@ -125,14 +131,12 @@ RUN \
 	sqlite-libs && \
  apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/community \
-	mxml && \
- apk add --no-cache \
-    --repository https://dl-cdn.alpinelinux.org/alpine/edge/testing \
-    librespot
+	mxml
 
 # copy buildstage and local files
 COPY --from=buildstage /tmp/daapd-build/ /
 COPY --from=buildstage /tmp/antlr3c-build/ /
+COPY --from=buildstage /tmp/libspotify-build/ /
 COPY root/ /
 
 # ports and volumes

--- a/README.md
+++ b/README.md
@@ -64,18 +64,6 @@ The web interface is available at `http://<your ip>:3689`
 
 For further setup options of remotes etc, check out the daapd website, [Owntone](https://owntone.github.io/owntone-server/).
 
-## Enable spotify connect server
-
-Enable the spotify connect server by creating a pipe named 'spotify' in the root of your mounted music folder (not possible on most network mounts):
-
-```sh
-mkfifo <music_folder>/spotify
-```
-
-The spotify connect server should show up as the 'forked-daapd' device in your Spotify application.
-
-It is recommended to set the `pipe_autostart` option to `true` in your forked-daapd config.
-
 ## Usage
 
 Here are some example snippets to help you get started creating a container.
@@ -158,6 +146,16 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
     uid=1000(dockeruser) gid=1000(dockergroup) groups=1000(dockergroup)
 ```
 
+&nbsp;
+
+## Application Setup
+
+Map your music folder, open up itunes on the same LAN to see your music there.
+
+The web interface is available at `http://<your ip>:3689`
+
+For further setup options of remotes etc, check out the owntone website, [owntone](https://ejurgensen.github.io/forked-daapd/).
+
 ## Docker Mods
 
 [![Docker Mods](https://img.shields.io/badge/dynamic/yaml?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=daapd&query=%24.mods%5B%27daapd%27%5D.mod_count&url=https%3A%2F%2Fraw.githubusercontent.com%2Flinuxserver%2Fdocker-mods%2Fmaster%2Fmod-list.yml)](https://mods.linuxserver.io/?mod=daapd "view available mods for this container.") [![Docker Universal Mods](https://img.shields.io/badge/dynamic/yaml?color=94398d&labelColor=555555&logoColor=ffffff&style=for-the-badge&label=universal&query=%24.mods%5B%27universal%27%5D.mod_count&url=https%3A%2F%2Fraw.githubusercontent.com%2Flinuxserver%2Fdocker-mods%2Fmaster%2Fmod-list.yml)](https://mods.linuxserver.io/?mod=universal "view available universal mods.")
@@ -237,7 +235,6 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **14.09.21:** - Enabled librespot. Disabled spotify on ARMv7
 * **10.07.21:** - Change of paths to work with the new package name, OwnTone.
 * **02.04.21:** - Update upstream repo, again.
 * **30.03.21:** - Update upstream repo.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -51,21 +51,8 @@ app_setup_block: |
 
   For further setup options of remotes etc, check out the daapd website, [Owntone]({{ project_url }}).
   
-  ## Enable spotify connect server
-
-  Enable the spotify connect server by creating a pipe named 'spotify' in the root of your mounted music folder (not possible on most network mounts):
-
-  ```sh
-  mkfifo <music_folder>/spotify
-  ```
-
-  The spotify connect server should show up as the 'forked-daapd' device in your Spotify application.
-
-  It is recommended to set the `pipe_autostart` option to `true` in your forked-daapd config.
-
 # changelog
 changelogs:
-  - { date: "14.09.21:", desc: "Enabled librespot. Disabled spotify on ARMv7" }
   - { date: "10.07.21:", desc: "Change of paths to work with the new package name, OwnTone." }
   - { date: "02.04.21:", desc: "Update upstream repo, again." }
   - { date: "30.03.21:", desc: "Update upstream repo." }

--- a/root/etc/services.d/librespot/run
+++ b/root/etc/services.d/librespot/run
@@ -1,2 +1,0 @@
-#!/usr/bin/execlineb -P
-librespot --backend pipe --device /music/spotify -n forked-daapd --cache /tmp


### PR DESCRIPTION
There are some inherent issues controlling librespot over the pipe with Owntone

Librespot was added as a workaround to make Spotify work on ARM platforms. However, Owntone 28.2 has added native Spotify support for all platforms.

Even though removing Librespot will eliminate Spotify connect support, the interface between Owntone and Librespot using a named pipe is far from perfect and has some corner cases that are hard to fix without any intervention (next to a difficult configuration, there is only one-way synchronization etc.). I propose therefore to remove it again from this library and wait/hope Owntone will one day support Spotify connect out of the box.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-daapd/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:

Removed my earlier PR on adding Librespot, since it is no longer needed, as already mentioned here: https://github.com/linuxserver/docker-daapd/issues/38 but somehow it still got merged.

## Benefits of this PR and context:

See above

## How Has This Been Tested?

Tested on Aarch64. AMD64 architectures are not impacted.

## Source / References:
https://github.com/owntone/owntone-server/pull/1253
